### PR TITLE
Add AuthContext and login button

### DIFF
--- a/backend/src/api/routes/auth.ts
+++ b/backend/src/api/routes/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, Router } from 'express';
 import * as authController from '../controllers/auth';
 import Util from '../util/Util';
+import JwtUtils from '../util/JwtUtils';
 
 const authRouter = Router();
 
@@ -12,6 +13,16 @@ authRouter.post('/google', async (req: Request, res: Response) => {
     res.cookie('user_id', userId, { httpOnly: true });
     res.cookie('access_token', accessToken, { httpOnly: true });
     Util.sendSuccess(res, 201, 'Successfully logged in', result);
+  } catch (error: unknown) {
+    return Util.sendFailure(res, error);
+  }
+});
+
+authRouter.post('/check-login', (req: Request, res: Response) => {
+  try {
+    const { access_token } = req.cookies;
+    JwtUtils.verifyAccessToken(access_token);
+    Util.sendSuccess(res, 200, 'Successfully authenticated', true);
   } catch (error: unknown) {
     return Util.sendFailure(res, error);
   }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,9 +6,8 @@ import {
   Navigate,
 } from 'react-router-dom';
 import MapPage from './pages/MapPage';
-import { getLocalStorageValue } from './utilities/localStorage';
-import { ACCESS_TOKEN_KEY, USER_ID_KEY } from './constants';
-import { ToastContext } from './utilities/context';
+import Api from './api/api';
+import { ToastContext, AuthContext } from './utilities/context';
 import LoginPage from './pages/LoginPage';
 import Toast from 'react-bootstrap/Toast';
 import ToastContainer from 'react-bootstrap/ToastContainer';
@@ -38,30 +37,36 @@ const TOAST_CONTENTS = {
 };
 
 function App() {
-  const [user, setUser] = useState();
+  const [user, setUser] = useState(false);
   const [toastType, setToastType] = useState(null);
 
   useEffect(() => {
-    setUser(
-      getLocalStorageValue(ACCESS_TOKEN_KEY) &&
-        getLocalStorageValue(USER_ID_KEY)
-    );
+    Api.makeApiRequest({
+      method: 'POST',
+      url: '/auth/check-login',
+    })
+      .then(() => setUser(true))
+      .catch(setUser(false));
   }, []);
 
   return (
     <>
-      <Router>
-        <ToastContext.Provider value={setToastType}>
-          <Routes>
-            <Route path="/home" className="app" element={<MapPage />} />
-            <Route
-              exact
-              path="/"
-              element={!user ? <LoginPage /> : <Navigate to="/home" replace />}
-            />
-          </Routes>
-        </ToastContext.Provider>
-      </Router>
+      <AuthContext.Provider value={{ user, setUser }}>
+        <Router>
+          <ToastContext.Provider value={setToastType}>
+            <Routes>
+              <Route path="/home" className="app" element={<MapPage />} />
+              <Route
+                exact
+                path="/"
+                element={
+                  !user ? <LoginPage /> : <Navigate to="/home" replace />
+                }
+              />
+            </Routes>
+          </ToastContext.Provider>
+        </Router>
+      </AuthContext.Provider>
 
       {toastType !== null && (
         <ToastContainer position="bottom-center">

--- a/frontend/src/components/LoginButton.jsx
+++ b/frontend/src/components/LoginButton.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { Link } from 'react-router-dom';
+
+import './LoginButton.scss';
+
+const LoginButton = () => {
+  return (
+    <Link to="/">
+      <button className="login-button">Log in to view</button>
+    </Link>
+  );
+};
+
+export default LoginButton;

--- a/frontend/src/components/LoginButton.scss
+++ b/frontend/src/components/LoginButton.scss
@@ -1,0 +1,24 @@
+@import '../custom.scss';
+
+.login-button {
+  color: white;
+  background-color: $primary;
+  border: 1px solid $primary;
+  border: 0;
+  border-radius: 4px;
+  font-weight: 600;
+  margin: 0 10px;
+  width: auto;
+  padding: 10px 30px;
+  transition: 0.2s;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+
+.login-button:hover {
+  cursor: pointer;
+  color: white;
+  box-shadow: 0 0 8px $primary;
+  background-color: $primary;
+}

--- a/frontend/src/components/ToiletDetail/PreferenceIcons.jsx
+++ b/frontend/src/components/ToiletDetail/PreferenceIcons.jsx
@@ -1,8 +1,10 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { FaHeart } from 'react-icons/fa';
 import { TiCancel } from 'react-icons/ti';
 import ToiletPreferenceControlller from '../../api/ToiletPreferenceController';
 import { PreferenceType } from '../../enums/ToiletPreferenceEnums';
+import { AuthContext } from '../../utilities/context';
 
 const PreferenceIcons = ({
   toiletId,
@@ -10,6 +12,8 @@ const PreferenceIcons = ({
   onSetPreferenceType,
 }) => {
   const [preference, setPreference] = useState(initPreferenceType);
+  const navigate = useNavigate();
+  const { setUser } = useContext(AuthContext);
 
   const updateToiletPreference = useCallback(
     async (type) => {
@@ -19,7 +23,8 @@ const PreferenceIcons = ({
           onSetPreferenceType(result.data.type);
         })
         .catch((e) => {
-          console.error(e);
+          setUser(false);
+          navigate('/');
         });
     },
     [toiletId, onSetPreferenceType]

--- a/frontend/src/components/ToiletDetail/ToiletRating.jsx
+++ b/frontend/src/components/ToiletDetail/ToiletRating.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback, useContext } from 'react';
 import Container from 'react-bootstrap/Container';
+import { useNavigate } from 'react-router-dom';
 import { TOILET_RATING } from '../../constants';
 import {
   getLocalStorageValue,
@@ -10,11 +11,13 @@ import ToiletRatingController from '../../api/ToiletRatingController';
 import { parseISO, differenceInMilliseconds } from 'date-fns';
 import ToiletRatingButtons from './ToiletRatingButtons';
 import ToiletRatingCountdown from './ToiletRatingCountdown';
-import { useCallback } from 'react';
+import { AuthContext } from '../../utilities/context';
 
 const ToiletRating = ({ toiletId, onRate }) => {
+  const navigate = useNavigate();
   const [nextRatingTime, setNextRatingTime] = useState(null);
   const rating_info_key = `rating_info_${toiletId}`;
+  const { setUser } = useContext(AuthContext);
 
   const clearNextRatingTime = useCallback(() => {
     removeLocalStorageValue(rating_info_key);
@@ -60,7 +63,10 @@ const ToiletRating = ({ toiletId, onRate }) => {
           updateRatingInfo(res.data);
           onRate();
         })
-        .catch((e) => console.log(e));
+        .catch((e) => {
+          setUser(false);
+          navigate('/');
+        });
     },
     [onRate, toiletId, updateRatingInfo]
   );

--- a/frontend/src/components/auth/GoogleAuth.jsx
+++ b/frontend/src/components/auth/GoogleAuth.jsx
@@ -1,13 +1,15 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { setLocalStorageValue } from '../../utilities/localStorage';
 import { ACCESS_TOKEN_KEY, USER_ID_KEY } from '../../constants';
 import { GoogleOAuthProvider, GoogleLogin } from '@react-oauth/google';
 import Api from '../../api/api';
 import './GoogleAuth.scss';
+import { AuthContext } from '../../utilities/context';
 
 const GoogleAuth = () => {
   const navigate = useNavigate();
+  const { setUser } = useContext(AuthContext);
   const [errorMsg, setErrorMsg] = useState('');
   const clientId = process.env.REACT_APP_GOOGLE_CLIENT_ID;
 
@@ -19,9 +21,10 @@ const GoogleAuth = () => {
           url: '/auth/google',
           data: { response },
         }).then((result) => {
-          const { userId, accessToken } = result.data;
-          setLocalStorageValue(ACCESS_TOKEN_KEY, accessToken);
-          setLocalStorageValue(USER_ID_KEY, userId);
+          setUser(true);
+          // const { userId, accessToken } = result.data;
+          // setLocalStorageValue(ACCESS_TOKEN_KEY, accessToken);
+          // setLocalStorageValue(USER_ID_KEY, userId);
           navigate('/home');
         });
       }

--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -17,10 +17,11 @@ import {
 import SearchBar from '../components/SearchBar';
 import ClusterDetails from '../components/ClusterDetail/ClusterDetails';
 import getMarkerIcon from '../components/markerIcon';
-import { ToastContext } from '../utilities/context';
+import { AuthContext, ToastContext } from '../utilities/context';
 import { getDistance } from '../utilities';
 import toiletReducer, { INITIAL_TOILET_STATE } from '../reducers/reducer';
 import VENUES from '../assets/venues.json';
+import LoginButton from '../components/LoginButton';
 
 import './MapPage.scss';
 import ToiletControlller from '../api/ToiletController';
@@ -35,6 +36,7 @@ const CIRCLE_FILL_OPTIONS = {
 const POLYLINE_FILL_OPTIONS = { color: '#4242a9' };
 
 const MapPage = () => {
+  const { user } = useContext(AuthContext);
   const PanZoomCenter = () => {
     const onPanZoomEnd = (map) => {
       const { lat, lng } = map.getCenter();
@@ -140,6 +142,7 @@ const MapPage = () => {
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
+        {!user && <LoginButton />}
         <SearchBar
           className="leaflet-top searchbar-row"
           state={state}

--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -17,11 +17,10 @@ import {
 import SearchBar from '../components/SearchBar';
 import ClusterDetails from '../components/ClusterDetail/ClusterDetails';
 import getMarkerIcon from '../components/markerIcon';
-import { AuthContext, ToastContext } from '../utilities/context';
+import { ToastContext } from '../utilities/context';
 import { getDistance } from '../utilities';
 import toiletReducer, { INITIAL_TOILET_STATE } from '../reducers/reducer';
 import VENUES from '../assets/venues.json';
-import LoginButton from '../components/LoginButton';
 
 import './MapPage.scss';
 import ToiletControlller from '../api/ToiletController';
@@ -36,7 +35,6 @@ const CIRCLE_FILL_OPTIONS = {
 const POLYLINE_FILL_OPTIONS = { color: '#4242a9' };
 
 const MapPage = () => {
-  const { user } = useContext(AuthContext);
   const PanZoomCenter = () => {
     const onPanZoomEnd = (map) => {
       const { lat, lng } = map.getCenter();
@@ -142,7 +140,6 @@ const MapPage = () => {
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
-        {!user && <LoginButton />}
         <SearchBar
           className="leaflet-top searchbar-row"
           state={state}

--- a/frontend/src/utilities/context.js
+++ b/frontend/src/utilities/context.js
@@ -1,3 +1,4 @@
-import { createContext } from "react";
+import { createContext } from 'react';
 
 export const ToastContext = createContext();
+export const AuthContext = createContext();


### PR DESCRIPTION
### Changes
- Use AuthContext instead of local storage to track user's authenticated state
- Add login button that can be used in the expandable favourites/blacklist footer
- Add check-login API call to verify JWT

On app start up, check-login API call will be made to set the AuthContext, which will be passed around in the app. If the JWT expires while the user is still browsing the app, protected actions (rating/favouriting/blacklisting) will trigger a change in AuthContext to set the `user` boolean field to false, and also redirect users back to the login page. 