### PR TITLE
Use local storage instead of cookies for auth token

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -17,15 +17,9 @@ export const getApp = () => {
   const swaggerDoc = YAML.load('./swagger.yml');
 
   // middleware
-  const corsConfig = {
-    origin: process.env.FRONTEND_APP_URL,
-    credentials: true,
-  };
-  app.use(cors(corsConfig));
-  app.options('*', cors(corsConfig));
+  app.use(cors());
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }));
-  app.use(cookieParser());
 
   // For Render.com to ping: https://stackoverflow.com/questions/72150113/nodejs-app-build-is-successful-render-but-application-error-in-render-at-the-l
   app.get('/', (_, res: Response) => {

--- a/backend/src/api/middlewares/auth.ts
+++ b/backend/src/api/middlewares/auth.ts
@@ -7,8 +7,8 @@ function authMiddleware(
   next: NextFunction
 ) {
   try {
-    const { access_token } = request.cookies;
-    JwtUtils.verifyAccessToken(access_token);
+    const accessToken = (request.headers['x-auth-token'] as string) ?? '';
+    JwtUtils.verifyAccessToken(accessToken);
     next();
   } catch (e: any) {
     response.status(401).send('Invalid JWT');

--- a/backend/src/api/routes/auth.ts
+++ b/backend/src/api/routes/auth.ts
@@ -9,16 +9,7 @@ authRouter.post('/google', async (req: Request, res: Response) => {
   try {
     const { credential } = req.body.response;
     const result = await authController.googleLogin(credential);
-    const { userId, accessToken } = result;
-    res.cookie('user_id', userId, {
-      secure: true,
-      sameSite: 'none',
-    });
-    res.cookie('access_token', accessToken, {
-      secure: true,
-      sameSite: 'none',
-    });
-    Util.sendSuccess(res, 201, 'Successfully logged in', true);
+    Util.sendSuccess(res, 201, 'Successfully logged in', result);
   } catch (error: unknown) {
     return Util.sendFailure(res, error);
   }
@@ -26,8 +17,8 @@ authRouter.post('/google', async (req: Request, res: Response) => {
 
 authRouter.post('/check-login', (req: Request, res: Response) => {
   try {
-    const { access_token } = req.cookies;
-    JwtUtils.verifyAccessToken(access_token);
+    const { accessToken } = req.body;
+    JwtUtils.verifyAccessToken(accessToken);
     Util.sendSuccess(res, 200, 'Successfully authenticated', true);
   } catch (error: unknown) {
     return Util.sendFailure(res, error);

--- a/backend/src/api/routes/preferences.ts
+++ b/backend/src/api/routes/preferences.ts
@@ -9,8 +9,7 @@ preferencesRouter.use(authMiddleware);
 
 preferencesRouter.put('/', async (req: Request, res: Response) => {
   try {
-    const { user_id } = req.cookies;
-    const payload: UpsertPreferenceDTO = { ...req.body, user_id };
+    const payload: UpsertPreferenceDTO = { ...req.body };
     const [result, isCreated] = await preferenceController.upsert(payload);
 
     if (isCreated) {
@@ -30,10 +29,10 @@ preferencesRouter.put('/', async (req: Request, res: Response) => {
 
 preferencesRouter.delete('/', async (req: Request, res: Response) => {
   try {
-    const { user_id } = req.cookies;
     const toiletId: string = req.query.toiletId as string;
+    const userId: string = req.query.userId as string;
     const result = await preferenceController.deleteByUserIdAndToiletId(
-      user_id,
+      userId,
       toiletId
     );
 
@@ -46,10 +45,10 @@ preferencesRouter.delete('/', async (req: Request, res: Response) => {
 preferencesRouter.get('/', async (req: Request, res: Response) => {
   try {
     let results;
-    const { user_id } = req.cookies;
+    const userId: string = req.query.userId as string;
 
-    if (user_id) {
-      results = await preferenceController.getByUserId(user_id);
+    if (userId) {
+      results = await preferenceController.getByUserId(userId);
     } else {
       results = await preferenceController.getAll();
     }

--- a/backend/src/api/routes/ratings.ts
+++ b/backend/src/api/routes/ratings.ts
@@ -12,10 +12,8 @@ ratingsRouter.use(authMiddleware);
 
 ratingsRouter.post('/', async (req: Request, res: Response) => {
   try {
-    const { user_id } = req.cookies;
-
     const payload: CreateRatingDTO = {
-      user_id: user_id,
+      user_id: req.body.user_id,
       toilet_id: req.body.toilet_id,
       type: req.body.type,
     };
@@ -38,11 +36,9 @@ ratingsRouter.get('/', async (_, res: Response) => {
 
 ratingsRouter.get('/last-rated', async (req: Request, res: Response) => {
   try {
-    const { user_id } = req.cookies;
-
     const payload: QueryRatingDTO = {
       toilet_id: req.query.toilet_id as string,
-      user_id: user_id,
+      user_id: req.query.user_id as string,
     };
     const results = await ratingController.getUserLastRated(payload);
     return Util.sendSuccess(res, 200, 'Retrieve last rating by user', results);

--- a/backend/src/api/routes/toilet/toilets.ts
+++ b/backend/src/api/routes/toilet/toilets.ts
@@ -45,11 +45,11 @@ toiletsRouter.delete('/:id', async (req: Request, res: Response) => {
 
 toiletsRouter.get('/neighbours', async (req: Request, res: Response) => {
   try {
-    const { user_id } = req.cookies;
+    const userId: string = req.query.userId as string;
     const coordinates = getCoordinatesFromReq(req);
     const results = await toiletController.getAllNeighbouringToilets(
       coordinates,
-      user_id
+      userId
     );
     return Util.sendSuccess(
       res,
@@ -66,9 +66,9 @@ toiletsRouter.get(
   '/with_user_preferences',
   async (req: Request, res: Response) => {
     try {
-      const { user_id } = req.cookies;
+      const userId: string = req.query.userId as string;
       const results = await toiletController.getToiletsWithUserPreferences(
-        user_id
+        userId
       );
       return Util.sendSuccess(
         res,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,8 @@ import LoginPage from './pages/LoginPage';
 import Toast from 'react-bootstrap/Toast';
 import ToastContainer from 'react-bootstrap/ToastContainer';
 import focused_face from './assets/focused_face.png';
+import { getLocalStorageValue } from './utilities/localStorage';
+import { ACCESS_TOKEN_KEY } from './constants';
 
 const TOAST_CONTENTS = {
   OFFLINE: {
@@ -41,9 +43,11 @@ function App() {
   const [toastType, setToastType] = useState(null);
 
   useEffect(() => {
+    const accessToken = getLocalStorageValue(ACCESS_TOKEN_KEY);
     Api.makeApiRequest({
       method: 'POST',
       url: '/auth/check-login',
+      data: { accessToken },
     })
       .then(() => setUser(true))
       .catch(() => setUser(false));

--- a/frontend/src/api/ToiletController.js
+++ b/frontend/src/api/ToiletController.js
@@ -3,10 +3,10 @@ import Api from './api';
 const TOILETS_URL = '/toilets';
 
 export default class ToiletControlller {
-  static async fetchCloseToilets(coordinates, radius) {
+  static async fetchCloseToilets(coordinates, radius, userId) {
     return Api.makeApiRequest({
       method: 'GET',
-      url: `${TOILETS_URL}/neighbours?latitude=${coordinates[0]}&longitude=${coordinates[1]}&radius=${radius}`,
+      url: `${TOILETS_URL}/neighbours?latitude=${coordinates[0]}&longitude=${coordinates[1]}&radius=${radius}&userId=${userId}`,
     });
   }
 
@@ -17,10 +17,10 @@ export default class ToiletControlller {
     });
   }
 
-  static async fetchToiletWithUserPreferences() {
+  static async fetchToiletWithUserPreferences(userId) {
     return Api.makeApiRequest({
       method: 'GET',
-      url: `${TOILETS_URL}/with_user_preferences`,
+      url: `${TOILETS_URL}/with_user_preferences?userId=${userId}`,
     });
   }
 }

--- a/frontend/src/api/ToiletPreferenceController.js
+++ b/frontend/src/api/ToiletPreferenceController.js
@@ -3,21 +3,24 @@ import Api from './api';
 const TOILET_PREFERENCE_URL = '/toilet_preferences';
 
 export default class ToiletPreferenceControlller {
-  static async updateToiletPreference(toiletId, type) {
+  static async updateToiletPreference(toiletId, type, userId, accessToken) {
     return Api.makeApiRequest({
       method: 'PUT',
       url: TOILET_PREFERENCE_URL,
       data: {
         toilet_id: toiletId,
+        user_id: userId,
         type,
       },
+      headers: { 'x-auth-token': accessToken },
     });
   }
 
-  static async deleteToiletPreference(toiletId) {
+  static async deleteToiletPreference(toiletId, userId, accessToken) {
     return Api.makeApiRequest({
       method: 'DELETE',
-      url: `${TOILET_PREFERENCE_URL}?toiletId=${toiletId}`,
+      url: `${TOILET_PREFERENCE_URL}?toiletId=${toiletId}&userId=${userId}`,
+      headers: { 'x-auth-token': accessToken },
     });
   }
 }

--- a/frontend/src/api/ToiletRatingController.js
+++ b/frontend/src/api/ToiletRatingController.js
@@ -3,21 +3,24 @@ import Api from './api';
 const TOILET_RATINGS_URL = '/toilet_ratings';
 
 export default class ToiletRatingController {
-  static async getUserLastRatedInfo(toilet_id) {
+  static async getUserLastRatedInfo(toilet_id, user_id, accessToken) {
     return await Api.makeApiRequest({
       method: 'GET',
       url: `${TOILET_RATINGS_URL}/last-rated`,
       params: {
         toilet_id: toilet_id,
+        user_id: user_id,
       },
+      headers: { 'x-auth-token': accessToken },
     });
   }
 
-  static async addUserRating(data) {
+  static async addUserRating(data, accessToken) {
     return await Api.makeApiRequest({
       method: 'POST',
       url: TOILET_RATINGS_URL,
       data: data,
+      headers: { 'x-auth-token': accessToken },
     });
   }
 }

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -7,7 +7,6 @@ export default class Api {
     try {
       const result = await axios({
         ...axiosConfig,
-        withCredentials: true,
         baseURL: BASE_URL,
       });
       return result.data;

--- a/frontend/src/components/ToiletDetail/PreferenceIcons.jsx
+++ b/frontend/src/components/ToiletDetail/PreferenceIcons.jsx
@@ -5,6 +5,8 @@ import { TiCancel } from 'react-icons/ti';
 import ToiletPreferenceControlller from '../../api/ToiletPreferenceController';
 import { PreferenceType } from '../../enums/ToiletPreferenceEnums';
 import { AuthContext } from '../../utilities/context';
+import { getLocalStorageValue } from '../../utilities/localStorage';
+import { ACCESS_TOKEN_KEY, USER_ID_KEY } from '../../constants';
 
 const PreferenceIcons = ({
   toiletId,
@@ -14,11 +16,17 @@ const PreferenceIcons = ({
   const [preference, setPreference] = useState(initPreferenceType);
   const navigate = useNavigate();
   const { setUser } = useContext(AuthContext);
+  const accessToken = getLocalStorageValue(ACCESS_TOKEN_KEY);
+  const userId = getLocalStorageValue(USER_ID_KEY);
 
   const updateToiletPreference = useCallback(
     async (type) => {
       if (type === preference) {
-        await ToiletPreferenceControlller.deleteToiletPreference(toiletId)
+        await ToiletPreferenceControlller.deleteToiletPreference(
+          toiletId,
+          userId,
+          accessToken
+        )
           .then((result) => {
             if (result.data) {
               setPreference(null);
@@ -30,7 +38,12 @@ const PreferenceIcons = ({
             navigate('/');
           });
       } else {
-        await ToiletPreferenceControlller.updateToiletPreference(toiletId, type)
+        await ToiletPreferenceControlller.updateToiletPreference(
+          toiletId,
+          type,
+          userId,
+          accessToken
+        )
           .then((result) => {
             setPreference(result.data.type);
             onSetPreferenceType(result.data.type);

--- a/frontend/src/components/ToiletDetail/ToiletRating.jsx
+++ b/frontend/src/components/ToiletDetail/ToiletRating.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useContext } from 'react';
 import Container from 'react-bootstrap/Container';
 import { useNavigate } from 'react-router-dom';
-import { TOILET_RATING } from '../../constants';
+import { ACCESS_TOKEN_KEY, TOILET_RATING, USER_ID_KEY } from '../../constants';
 import {
   getLocalStorageValue,
   removeLocalStorageValue,
@@ -18,6 +18,8 @@ const ToiletRating = ({ toiletId, onRate }) => {
   const [nextRatingTime, setNextRatingTime] = useState(null);
   const rating_info_key = `rating_info_${toiletId}`;
   const { setUser } = useContext(AuthContext);
+  const accessToken = getLocalStorageValue(ACCESS_TOKEN_KEY);
+  const userId = getLocalStorageValue(USER_ID_KEY);
 
   const clearNextRatingTime = useCallback(() => {
     removeLocalStorageValue(rating_info_key);
@@ -55,10 +57,11 @@ const ToiletRating = ({ toiletId, onRate }) => {
       const data = {
         toilet_id: toiletId,
         type: rating,
+        user_id: userId,
       };
 
       // TODO: Handle error
-      await ToiletRatingController.addUserRating(data)
+      await ToiletRatingController.addUserRating(data, accessToken)
         .then((res) => {
           updateRatingInfo(res.data);
           onRate();
@@ -86,7 +89,11 @@ const ToiletRating = ({ toiletId, onRate }) => {
 
       // No info stored in cache, check with backend
       if (!rating_info) {
-        return await ToiletRatingController.getUserLastRatedInfo(toiletId)
+        return await ToiletRatingController.getUserLastRatedInfo(
+          toiletId,
+          userId,
+          accessToken
+        )
           .then((res) => {
             const data = res.data;
 

--- a/frontend/src/components/ToiletPreferencesModal/ToiletPreferencesModal.jsx
+++ b/frontend/src/components/ToiletPreferencesModal/ToiletPreferencesModal.jsx
@@ -5,6 +5,8 @@ import { FaHeart } from 'react-icons/fa';
 import { FiChevronDown, FiChevronUp } from 'react-icons/fi';
 import { TiCancel } from 'react-icons/ti';
 import ToiletControlller from '../../api/ToiletController';
+import { USER_ID_KEY } from '../../constants';
+import { getLocalStorageValue } from '../../utilities/localStorage';
 import ToiletList from '../ToiletList/ToiletList';
 import styles from './ToiletPreferencesModal.module.scss';
 
@@ -20,10 +22,11 @@ const ToiletPreferencesModal = ({ state }) => {
   });
   const [blacklistedToilets, setBlacklistedToilets] = useState([]);
   const [favouritedToilets, setFavouritedToilets] = useState([]);
+  const userId = getLocalStorageValue(USER_ID_KEY);
 
   // TODO: Fetch toilets whenever user changes preferences (can add action to useContext)
   const fetchToiletsWithPreferences = useCallback(() => {
-    ToiletControlller.fetchToiletWithUserPreferences()
+    ToiletControlller.fetchToiletWithUserPreferences(userId)
       .then((result) => {
         setBlacklistedToilets(result.data.blacklistedToilets);
         setFavouritedToilets(result.data.favouritedToilets);

--- a/frontend/src/components/auth/GoogleAuth.jsx
+++ b/frontend/src/components/auth/GoogleAuth.jsx
@@ -4,6 +4,8 @@ import { GoogleOAuthProvider, GoogleLogin } from '@react-oauth/google';
 import Api from '../../api/api';
 import './GoogleAuth.scss';
 import { AuthContext } from '../../utilities/context';
+import { setLocalStorageValue } from '../../utilities/localStorage';
+import { ACCESS_TOKEN_KEY, USER_ID_KEY } from '../../constants';
 
 const GoogleAuth = () => {
   const navigate = useNavigate();
@@ -18,7 +20,10 @@ const GoogleAuth = () => {
           method: 'POST',
           url: '/auth/google',
           data: { response },
-        }).then(() => {
+        }).then((result) => {
+          const { accessToken, userId } = result.data;
+          setLocalStorageValue(ACCESS_TOKEN_KEY, accessToken);
+          setLocalStorageValue(USER_ID_KEY, userId);
           setUser(true);
           navigate('/home');
         });

--- a/frontend/src/pages/MapPage.jsx
+++ b/frontend/src/pages/MapPage.jsx
@@ -26,6 +26,8 @@ import styles from './MapPage.module.scss';
 import ToiletControlller from '../api/ToiletController';
 import { getToiletsBreakdown } from '../utilities/Util';
 import ToiletPreferencesModal from '../components/ToiletPreferencesModal/ToiletPreferencesModal';
+import { getLocalStorageValue } from '../utilities/localStorage';
+import { USER_ID_KEY } from '../constants';
 
 const CIRCLE_FILL_OPTIONS = {
   fillOpacity: 1,
@@ -58,10 +60,11 @@ const MapPage = () => {
   const setToastType = useContext(ToastContext);
   const [state, dispatch] = useReducer(toiletReducer, INITIAL_TOILET_STATE);
   const [map, setMap] = useState(null);
+  const userId = getLocalStorageValue(USER_ID_KEY);
 
   const fetchCloseToilets = useCallback(
     (coordinates, radius) => {
-      ToiletControlller.fetchCloseToilets(coordinates, radius)
+      ToiletControlller.fetchCloseToilets(coordinates, radius, userId)
         .then((result) => {
           dispatch({ type: 'updateToilets', payload: result.data });
         })


### PR DESCRIPTION
### Changes
Previously, we used cookies to store the access token. However, on Safari, the cookies might not be stored properly because of some default settings (e.g. prevent cross-site tracking, which affects the app since our BE and FE use different domains). Swapping to use local storage to see if it works better.