### PR TITLE
Add hashcode to generate toilet quotes

### DIFF
--- a/frontend/src/components/ToiletDetail/ToiletDetail.jsx
+++ b/frontend/src/components/ToiletDetail/ToiletDetail.jsx
@@ -7,7 +7,11 @@ import { GrFormPreviousLink } from 'react-icons/gr';
 import ToiletControlller from '../../api/ToiletController';
 import { Utilities } from '../../enums/ToiletEnums';
 
-import { getCleanlinessMetadata, getToiletName } from '../../utilities/Util';
+import {
+  getCleanlinessMetadata,
+  getToiletName,
+  getToiletQuote,
+} from '../../utilities/Util';
 import PreferenceIcons from './PreferenceIcons';
 import styles from './ToiletDetail.module.scss';
 import ToiletRating from './ToiletRating';
@@ -17,6 +21,9 @@ const ToiletDetail = ({ building, toilet, isShow, onBack, onHide }) => {
   const { id, description, utilities } = toilet;
   const setToastType = useContext(ToastContext);
 
+  const [toiletQuote, setToiletQuote] = useState(
+    'Haha our website clogged just like the toilet cannot flush'
+  );
   const [cleanlinessMetadata, setCleanlinessMetadata] = useState({
     text: 'BAD',
     type: 'danger',
@@ -30,6 +37,9 @@ const ToiletDetail = ({ building, toilet, isShow, onBack, onHide }) => {
         setPercentageBeat(result.data.percentageBeat);
         setCleanlinessMetadata(getCleanlinessMetadata(cleanliness));
         toilet.cleanliness = cleanliness;
+
+        const newToiletQuote = getToiletQuote(cleanliness, id);
+        setToiletQuote(newToiletQuote);
       })
       .catch((e) => {
         setToastType('ERROR');
@@ -65,9 +75,7 @@ const ToiletDetail = ({ building, toilet, isShow, onBack, onHide }) => {
       </Offcanvas.Header>
       <Offcanvas.Body>
         <div className={styles['toilet-summary']}>
-          <p className={styles['toilet-summary-item']}>
-            {cleanlinessMetadata.quote}
-          </p>
+          <p className={styles['toilet-summary-item']}>{toiletQuote}</p>
 
           <img
             className={styles['toilet-summary-item']}

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -90,18 +90,15 @@ export const TOILET_CLEANLINESS_METADATA = {
     text: 'GOOD',
     type: 'success',
     icon: clean_toilet,
-    quote: TOILET_QUOTES.GOOD[0],
   },
   BAD: {
     text: 'BAD',
     type: 'danger',
     icon: dirty_toilet,
-    quote: TOILET_QUOTES.BAD[0],
   },
   AVERAGE: {
     text: 'AVERAGE',
     type: 'warning',
     icon: normal_toilet,
-    quote: TOILET_QUOTES.AVERAGE[0],
   },
 };

--- a/frontend/src/utilities/Util.js
+++ b/frontend/src/utilities/Util.js
@@ -4,12 +4,13 @@ import { getOrder } from '../enums/ToiletPreferenceEnums';
 const DIRTY_CLEANLINESS_VALUE = -0.25;
 const CLEAN_CLEANLINESS_VALUE = 0.25;
 
-const getRandomToiletQuote = (quotes) => {
-  const idx = Math.floor(Math.random() * quotes.length);
-  return quotes[idx];
-};
+// https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0
+const hashCode = (str) =>
+  Math.abs(
+    str.split('').reduce((s, c) => (Math.imul(31, s) + c.charCodeAt(0)) | 0, 0)
+  );
 
-export const getCleanlinessMetadata = (cleanliness) => {
+const getCleanlinessKey = (cleanliness) => {
   let key = '';
   if (cleanliness < DIRTY_CLEANLINESS_VALUE) {
     key = 'BAD';
@@ -18,11 +19,20 @@ export const getCleanlinessMetadata = (cleanliness) => {
   } else {
     key = 'AVERAGE';
   }
+  return key;
+};
 
-  const metadata = TOILET_CLEANLINESS_METADATA[key];
-  const quote = getRandomToiletQuote(TOILET_QUOTES[key]);
-  metadata.quote = quote;
-  return metadata;
+export const getToiletQuote = (cleanliness, id) => {
+  const key = getCleanlinessKey(cleanliness);
+  const quotes = TOILET_QUOTES[key];
+  const idx = hashCode(id) % quotes.length;
+
+  return quotes[idx];
+};
+
+export const getCleanlinessMetadata = (cleanliness) => {
+  const key = getCleanlinessKey(cleanliness);
+  return TOILET_CLEANLINESS_METADATA[key];
 };
 
 export const getToiletsBreakdown = (toilets) =>


### PR DESCRIPTION
Initially the quotes were randomly generated and doesn't look good on the UI. Updated to use the `Toilet.id` to generate a hash which maps to an index in one of the existing `TOILET_QUOTES`